### PR TITLE
Updated references to companion paper with published version and fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![DOI](https://zenodo.org/badge/695291842.svg)](https://zenodo.org/badge/latestdoi/695291842)
 
-This code represents a custom outlier rejection algorithm for JWST/NIRSpec IFS data, described in Hutchison et al., submitted to PASP (arxiv:2312.12518).  The algorithm has been split into different jupyter notebooks in order to make it easier to parse and easier to test/troubleshoot specific sections for your own data.
+This code represents a custom outlier rejection algorithm for JWST/NIRSpec IFS data, described in [Hutchison et al. (2024)](https://doi.org/10.1088/1538-3873/ad34fd).  The algorithm has been split into different jupyter notebooks in order to make it easier to parse and easier to test/troubleshoot specific sections for your own data.
 
 
 ### Order of Operations

--- a/generating-target-mask.ipynb
+++ b/generating-target-mask.ipynb
@@ -424,7 +424,7 @@
    "source": [
     "#### Sometimes you may need to add or remove a spaxel from the mask\n",
     "\n",
-    "This is because we're working with the straight-from-the-pipeline cubes, so there will be some artifacts or bad pixels that may mess up the S/N for a particular spaxel.  To fix this, uncomment the following code cell and then change the `y` and `x` in the brakets into numbers and rerun the plotting cell above until you're centered on the pixel you want to change.  Then, change the `np.nan` to a `1` or `0` -- depending upon if you wanted to include or remove the pixel from the mask.\n",
+    "This is because we're working with the straight-from-the-pipeline cubes, so there will be some artifacts or bad pixels that may mess up the S/N for a particular spaxel.  To fix this, uncomment the following code cell and then change the `y` and `x` in the brackets into numbers and rerun the plotting cell above until you're centered on the pixel you want to change.  Then, change the `np.nan` to a `1` or `0` -- depending upon if you wanted to include or remove the pixel from the mask.\n",
     "\n",
     "Copy-paste this line of code to change more pixels as needed."
    ]
@@ -544,7 +544,7 @@
    "id": "026df22d-3110-4658-9874-a136337ba5b5",
    "metadata": {},
    "source": [
-    "### Let's look at those layers indiviudally"
+    "### Let's look at those layers individually"
    ]
   },
   {

--- a/layered-sigma-clipping.PART2.ipynb
+++ b/layered-sigma-clipping.PART2.ipynb
@@ -11,7 +11,7 @@
     "on behalf of the TEMPLATES team.\n",
     "\n",
     "\n",
-    "This is the second step in the sigma clipping part of the algorithm described in H+, section 2.2.2.  In this step, we use a layered sigma cliping process on the science target spaxels in the IFU cube, saving the output to its own FITS file to be read in at the final step."
+    "This is the second step in the sigma clipping part of the algorithm described in H+, section 2.2.2.  In this step, we use a layered sigma clipping process on the science target spaxels in the IFU cube, saving the output to its own FITS file to be read in at the final step."
    ]
   },
   {
@@ -20,7 +20,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-success\">\n",
-    "    <b>NOTE</b> -- this step will likely be the most hands-on of the entire algorithm.  As described in H+, some adjustement may be needed between this step and the part of the mask making code where you define the S/N layers for your science target (generally, this just means shifting the S/N ranges for each layer and rerunning this step to see how it changed).\n",
+    "    <b>NOTE</b> -- this step will likely be the most hands-on of the entire algorithm.  As described in H+, some adjustment may be needed between this step and the part of the mask making code where you define the S/N layers for your science target (generally, this just means shifting the S/N ranges for each layer and rerunning this step to see how it changed).\n",
     "</div>"
    ]
   },
@@ -196,7 +196,7 @@
     "# LOOKING AT 1D AROUND BENCHMARK SLICE IN 1D\n",
     "# ------------------------------------------\n",
     "\n",
-    "wave_mask = get_benchmark_wave_index(datacube,sli,header) # indicies around benchmark slice\n",
+    "wave_mask = get_benchmark_wave_index(datacube,sli,header) # indices around benchmark slice\n",
     "\n",
     "# pulling spectrum at each benchmark spaxel\n",
     "spec = get_spec(x,y,datacube,errorcube,header)\n",
@@ -516,7 +516,7 @@
     "# LOOKING AT 1D AROUND BENCHMARK SLICE IN 1D\n",
     "# ------------------------------------------\n",
     "\n",
-    "wave_mask = get_benchmark_wave_index(datacube,sli,header) # indicies around benchmark slice\n",
+    "wave_mask = get_benchmark_wave_index(datacube,sli,header) # indices around benchmark slice\n",
     "\n",
     "# pulling spectrum at each benchmark spaxel, in clipped data & error cubes\n",
     "spec = get_spec(x,y,data_clipped,error_clipped,header)\n",
@@ -557,7 +557,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-success\">\n",
-    "    Check out the <b>troubleshooting_visually.py</b> helper plotting functions if you want more ways to explore the data before and after the layered sigam clipping step -- they include functions to plot IFU slices, find spaxels, plot spaxel spectra, etc.\n",
+    "    Check out the <b>troubleshooting_visually.py</b> helper plotting functions if you want more ways to explore the data before and after the layered sigma clipping step -- they include functions to plot IFU slices, find spaxels, plot spaxel spectra, etc.\n",
     "</div>"
    ]
   },

--- a/routines.py
+++ b/routines.py
@@ -1,9 +1,9 @@
 '''
 
 Series of helper functions for use in the layered sigma-clipping algorithm 
-defined in Hutchison et al., submitted to PASP.
+defined in Hutchison et al. (2024).
 
-To read more, see arxiv.org/abs/2312.12518
+To read more, see https://doi.org/10.1088/1538-3873/ad34fd
 
 Created by Dr. Taylor Hutchison, NASA GSFC,
 on behalf of the TEMPLATES team.


### PR DESCRIPTION
I noticed that the references to the companion paper still point to the arXiv pre-print, so I updated them to instead point to the published version in PASP. I also corrected some typos I saw.